### PR TITLE
Added the Built Environment Ontology Lookup Service (BE-OLS) to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ See also:
 * [BARTOC (Basel Register of Thesauri, Ontologies & Classifications)](https://bartoc.org) - Database of Knowledge Organization Systems and KOS related Registries, developed by the Basel University Library, Switzerland.
 * [DBpedia Archivo](https://archivo.dbpedia.org/list) - Ontology archive automatically indexing OWL ontologies on the web.
 * <http://www.ontologydesignpatterns.org/ont/> in [OntologyDesignPatterns.org](http://ontologydesignpatterns.org/) (ODP)
-* [Built Environment Ontology Lookup Service (BE-OLS)](https://cyberbuildlab.github.io/BE-OLS/) - a list and analysis of 140+ built environment-related ontologies
+
 
 Archived or inactive:
 
@@ -193,8 +193,9 @@ See also:
 
 ### Domain Ontologies
 
-#### Architecture
+#### Built Environment
 
+* [Built Environment Ontology Lookup Service (BE-OLS)](https://cyberbuildlab.github.io/BE-OLS/) - a list and analysis of 140+ built environment-related ontologies
 * [Digital Buildings Ontology (DBO)](https://github.com/google/digitalbuildings) - Ontology for buildings and building-installed equipment by Google.
 
 #### Biology

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ See also:
 * [BARTOC (Basel Register of Thesauri, Ontologies & Classifications)](https://bartoc.org) - Database of Knowledge Organization Systems and KOS related Registries, developed by the Basel University Library, Switzerland.
 * [DBpedia Archivo](https://archivo.dbpedia.org/list) - Ontology archive automatically indexing OWL ontologies on the web.
 * <http://www.ontologydesignpatterns.org/ont/> in [OntologyDesignPatterns.org](http://ontologydesignpatterns.org/) (ODP)
+* [Built Environment Ontology Lookup Service (BE-OLS)](https://cyberbuildlab.github.io/BE-OLS/) - a list and analysis of 140+ built environment-related ontologies
 
 Archived or inactive:
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ See also:
 
 ### Domain Ontologies
 
-#### Built Environment
+#### Architecture & Built Environment
 
 * [Built Environment Ontology Lookup Service (BE-OLS)](https://cyberbuildlab.github.io/BE-OLS/) - a list and analysis of 140+ built environment-related ontologies
 * [Digital Buildings Ontology (DBO)](https://github.com/google/digitalbuildings) - Ontology for buildings and building-installed equipment by Google.


### PR DESCRIPTION
Added this line to the readme
* [Built Environment Ontology Lookup Service (BE-OLS)](https://cyberbuildlab.github.io/BE-OLS/) - a list and analysis of 140+ built environment-related ontologies

Changed the word Architecture (under the domain ontologies) to Built Environment as this term is used more now.